### PR TITLE
Set time backwards might happen in threaded environments

### DIFF
--- a/flux/timeline.py
+++ b/flux/timeline.py
@@ -89,7 +89,7 @@ class Timeline(object):
     def set_time(self, time):
         delta = time - self.time()
         if delta < 0:
-            raise ValueError("Cannot set time to the past")
+            return # Can't move time backwards. Not an exception, if using threads.
         self._time_correction.shift += delta
     def time(self):
         """

--- a/tests/test__timeline.py
+++ b/tests/test__timeline.py
@@ -69,8 +69,9 @@ class TimelineAPITest(TimelineTestBase):
 
     def test__cannot_set_past_time(self):
         self.timeline.set_time(self.timeline.time() + 10)
-        with self.assertRaises(ValueError):
-            self.timeline.set_time(self.timeline.time() - 1)
+        current_time = self.timeline.time()
+        self.timeline.set_time(self.timeline.time() - 1)
+        self.assertEqual(self.timeline.time(), current_time)
 
 
 class TimeFactorTest(TestCase):


### PR DESCRIPTION
When using two or more threads using the same timeline, set_time(self, time) might be executed simultaneously by two threads. This might cause time to be set backwards by the latter call. Instead of an error, ignore attempt.

This is not the perfect solution, but is probably good enough.
