### PR TITLE
Ensure gevent switch on sleep

### DIFF
--- a/flux/gevent_timeline.py
+++ b/flux/gevent_timeline.py
@@ -3,8 +3,8 @@ from .timeline import Timeline
 class GeventTimeline(Timeline):
     def sleep(self, seconds):
         super(GeventTimeline, self).sleep(seconds)
-        if self._time_factor == 0:
-            self._real_sleep(0.0)
+        self._real_sleep(0.0)
+
     def _real_sleep(self, seconds):
         try:
             import gevent


### PR DESCRIPTION
Because _real_sleep is not always called in Timeline.sleep, gevent switch doesn't happen when expected. We need to allow switch for gevent when sleep is called.